### PR TITLE
feat: add today button header to jump to current day

### DIFF
--- a/src/calendar/components/EthiopianCalendar.tsx
+++ b/src/calendar/components/EthiopianCalendar.tsx
@@ -127,6 +127,11 @@ export const EthiopianCalender: React.FC<EthiopianCalenderProps> = (props) => {
     ).year as number;
   }, []);
 
+  const gotoToday = useCallback(()=> {
+      setMonth(currentMonthIndex)
+      setYear(currentYear)
+  }, [currentYear, currentMonthIndex])
+
   const next = useCallback(() => {
     const newMonth = month + 1;
     if (newMonth > 13) {
@@ -198,6 +203,8 @@ export const EthiopianCalender: React.FC<EthiopianCalenderProps> = (props) => {
   return (
     <View style={styles.container}>
       <Header
+        currentDay={currentDay}
+        today={gotoToday}
         next={next}
         prev={prev}
         month={month}
@@ -219,7 +226,7 @@ export const EthiopianCalender: React.FC<EthiopianCalenderProps> = (props) => {
             theme={theme}
           />
         ))}
-        {/* EXCEPT TO ጳጉሜ, EVERY OTHET MONTH HAS EXACTLY 30 DAYS.*/}
+        {/* EXCEPT TO ጳጉሜ, EVERY OTHER MONTH HAS EXACTLY 30 DAYS.*/}
         {month !== 13
           ? iterator(30).map((_item, i) => (
               <Day

--- a/src/calendar/components/GregorianCalender.tsx
+++ b/src/calendar/components/GregorianCalender.tsx
@@ -65,6 +65,11 @@ export const GregorianCalendar: React.FC<GregorianCalendar> = (props) => {
     return 7 - lastDayOfTheMonthIndex - 1;
   }, [lastDayOfTheMonthIndex]);
 
+  const gotoToday = useCallback(()=> {
+      setMonth(currentMonthIndex)
+      setYear(currentYear)
+  }, [currentYear, currentMonthIndex])
+
   const next = useCallback(() => {
     const newMonth = month + 1;
     if (newMonth > 12) {
@@ -149,6 +154,8 @@ export const GregorianCalendar: React.FC<GregorianCalendar> = (props) => {
   return (
     <View style={styles.container}>
       <Header
+        currentDay={currentDay}
+        today={gotoToday}
         next={next}
         prev={prev}
         month={month}

--- a/src/calendar/components/header/index.tsx
+++ b/src/calendar/components/header/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Image, Text, TouchableOpacity, View } from 'react-native';
+import { Button, Image, Text, TouchableOpacity, View } from 'react-native';
 import type { LanguageCode, Mode } from '../../../utils/locals/types';
 import { getDaysNameOfTheWeek, getMonthsName } from '../../../utils/locals';
 import { makeStyle } from './style';
@@ -7,6 +7,8 @@ import type { Theme } from '../../../types';
 import { LocalsDropDown, SwitchMode } from '../../../commons/components';
 
 type DayProps = {
+  currentDay: number;
+  today: () => void;
   prev: () => void;
   next: () => void;
   month: number;
@@ -21,6 +23,8 @@ type DayProps = {
 
 export const Header: React.FC<DayProps> = React.memo((props) => {
   const {
+    currentDay,
+    today,
     prev,
     next,
     month,
@@ -40,6 +44,11 @@ export const Header: React.FC<DayProps> = React.memo((props) => {
       {!hideHeaderButtons && (
         <View style={styles.headerButtonsWrapper}>
           <SwitchMode theme={theme} mode={mode} onModeChange={onModeChange} />
+          <View style={styles.todayButton}>
+            <TouchableOpacity onPress={today} activeOpacity={0.9}>
+              <Text style={styles.todayText}>{currentDay}</Text>
+            </TouchableOpacity>
+          </View>
           {mode === 'EC' && (
             <LocalsDropDown
               theme={theme}

--- a/src/calendar/components/header/style.ts
+++ b/src/calendar/components/header/style.ts
@@ -32,6 +32,27 @@ export const makeStyle = (theme: Theme = {}) => {
     headerTitle: {
       flexDirection: 'row',
     } as ViewStyle,
+    todayButton: {
+      /* borderRadius: 10, */
+      backgroundColor: mergedStyles.headerBackgroundColor,
+      backgroundColor: mergedStyles.localsDropdownBackgroundColor,
+      alignItems: 'center',
+      padding: 5,
+      paddingHorizontal: 10,
+      shadowColor: '#000',
+      shadowOffset: {
+        width: 0,
+        height: 2,
+      },
+      shadowOpacity: 0.25,
+      shadowRadius: 3.84,
+
+      elevation: 5,
+    } as ViewStyle,
+    todayText: {
+      color: mergedStyles.todayTextColor,
+      fontSize: mergedStyles.textMonthFontSize,
+    } as ViewStyle,
     titleText: {
       fontSize: mergedStyles.textMonthFontSize,
       fontFamily: mergedStyles.textMonthFontFamily,


### PR DESCRIPTION
Added a button that shows **current day in number** and onclick goes/jumps directly to the _current day._

![Screenshot_20230604_154856_Expo Go](https://github.com/leulseged3/react-native-ethiopian-calendar/assets/39951554/eb2da950-fe90-4335-9d62-b040825fc953)
![Screenshot_20230604_154915_Expo Go](https://github.com/leulseged3/react-native-ethiopian-calendar/assets/39951554/f1c031a8-1ff5-45fd-b0b5-d3053334a4e5)
